### PR TITLE
Make constants customizable

### DIFF
--- a/public/publish.php
+++ b/public/publish.php
@@ -4,17 +4,26 @@ $root = realpath(dirname(__DIR__));
 
 require_once "$root/vendor/autoload.php";
 
-define('WPR_LOG', 'php://stdout');
-define('WPR_CACHE', "$root/cache");
-define('WPR_CONFIG', "$root/satis.json");
-define('WPR_EXPIRE', 365 * 24 * 60 * 60);
-define('WPR_SOURCE', "$root/artifacts");
-define('WPR_TARGET', "$root/public");
-
 if (file_exists("$root/config.php")) {
     require_once "$root/config.php";
 }
 
+$defaults = [
+    'WPR_LOG' => 'php://stdout',
+    'WPR_CACHE' => "$root/cache",
+    'WPR_CONFIG' => "$root/satis.json",
+    'WPR_EXPIRE' => 365 * 24 * 60 * 60,
+    'WPR_SOURCE' => "$root/artifacts",
+    'WPR_TARGET' => "$root/public",
+];
+
+foreach ($defaults as $key => $value) {
+    defined($key) || define($key, $value);
+}
+
 unset($root);
+unset($defaults);
+unset($key);
+unset($value);
 
 (new \WPRepo\Application())->run();


### PR DESCRIPTION
Since _constants_ cannot be overridden (duh), check if they're defined before setting them.

This will also enable us to have multiple repositories in the same installation, with a little bit of effort:

- `public/alpaca/publish.php`:

```php
<?php

$name = basename(__DIR__);
$root = realpath(dirname(dirname(__DIR__)));
$private = realpath("$root/private/$name");

require_once "$private/config.php";

define('WPR_CACHE', "$root/cache");
define('WPR_CONFIG', "$private/satis.json");
define('WPR_SOURCE', "$private/artifacts");
define('WPR_TARGET', "$root/public/$name");

require_once "$root/public/publish.php";
```